### PR TITLE
Atualiza nomes de variáveis MNI na documentação

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ SECRET_KEY=y8K#2pL9qW@7vBzQxR4dTmN5sX6fHjU
 PORT=5000
 
 # Credenciais MNI/PJe (opcional - pode ser passado nos headers)
-MNI_CPF=06293234456
-MNI_SENHA=Simb@280303
+MNI_ID_CONSULTANTE=06293234456
+MNI_SENHA_CONSULTANTE=Simb@280303
 
 # Configurações do Banco de Dados (se usar)
 DATABASE_URL=postgresql://railway:wMnAMYT_-xf!B94D_2VTR4p3*sBBsUxt@postgres.railway.internal:5432/railway

--- a/DEPLOY_INSTRUCTIONS.md
+++ b/DEPLOY_INSTRUCTIONS.md
@@ -83,8 +83,8 @@ SESSION_SECRET=uma-chave-secreta-longa-e-aleatoria
 
 Opcionais (se usar API MNI):
 ```
-MNI_CPF=seu-cpf
-MNI_SENHA=sua-senha
+MNI_ID_CONSULTANTE=seu-cpf-ou-cnpj
+MNI_SENHA_CONSULTANTE=sua-senha
 ```
 
 ## Testando localmente

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ Para deploy no Vercel, use o arquivo `vercel.json` incluído.
 
 - `DATABASE_URL`: URL de conexão com PostgreSQL
 - `SESSION_SECRET`: Chave secreta para sessões
-- `MNI_CPF`: CPF para acesso à API MNI (opcional)
-- `MNI_SENHA`: Senha para acesso à API MNI (opcional)
+- `MNI_ID_CONSULTANTE`: CPF ou CNPJ do consultante para a API MNI (opcional)
+- `MNI_SENHA_CONSULTANTE`: Senha do consultante para a API MNI (opcional)
 
 ## API Endpoints
 


### PR DESCRIPTION
## Summary
- atualiza variáveis de ambiente no README
- ajusta exemplo de `.env` e instruções de deploy para usar `MNI_ID_CONSULTANTE` e `MNI_SENHA_CONSULTANTE`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683f8e622450832c8b762358e01cf06d